### PR TITLE
Improve chat project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Maven
+/target/
+*.log
+
+# IDE files
+/.idea/
+*.iml
+
+# compiled java
+*.class

--- a/README.md
+++ b/README.md
@@ -1,7 +1,60 @@
 # chat-app-usingsocket
-chat application using java
-to run it on cmd
-1)javac *.java
-2)java Multiserv
-on other cmd
-3)java Multiclient
+
+This project is now a Spring Boot WebSocket chat server with a small HTTP API and an optional web client. The original socket-based classes remain in the `tcp/` directory for reference, but the recommended way to run the application is via Spring Boot.
+
+## Building
+
+Use Maven to build the project:
+
+```bash
+mvn package
+```
+
+## Running
+
+Launch the Spring Boot application with:
+
+```bash
+mvn spring-boot:run
+```
+
+The WebSocket endpoint is available at `/chat` and messages are broadcast on the `/topic/messages` destination. A small web client is served from the application root so you can test the chat in a browser.
+
+Clients can connect using any STOMP/WebSocket client or send messages via a REST call:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+     -d '{"from":"bob","content":"hello"}' http://localhost:8080/send
+```
+
+## Chat History
+
+The server retains the last 100 messages in memory, each tagged with a timestamp. You can retrieve this history via a simple HTTP GET request:
+
+```bash
+curl http://localhost:8080/history
+```
+
+## Presence API
+
+Clients can register themselves with the server so others know who is online. The server broadcasts the user list on `/topic/users` whenever it changes.
+
+Join the chat:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+     -d '{"name":"bob"}' http://localhost:8080/join
+```
+
+Leave the chat:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+     -d '{"name":"bob"}' http://localhost:8080/leave
+```
+
+List current users:
+
+```bash
+curl http://localhost:8080/users
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>chat-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Chat Application</name>
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.2.0</spring.boot.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/chat/ChatApplication.java
+++ b/src/main/java/com/example/chat/ChatApplication.java
@@ -1,0 +1,11 @@
+package com.example.chat;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ChatApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ChatApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/chat/ChatController.java
+++ b/src/main/java/com/example/chat/ChatController.java
@@ -1,0 +1,69 @@
+package com.example.chat;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import com.example.chat.dto.UserRequest;
+
+import java.util.List;
+
+@Controller
+public class ChatController {
+
+    private final ChatService service;
+    private final SimpMessagingTemplate template;
+
+    public ChatController(ChatService service, SimpMessagingTemplate template) {
+        this.service = service;
+        this.template = template;
+    }
+
+    @MessageMapping("/chat")
+    @SendTo("/topic/messages")
+    public ChatMessage websocket(ChatMessage message) {
+        return service.addMessage(message);
+    }
+
+    @PostMapping("/send")
+    @ResponseBody
+    public ChatMessage send(@RequestBody ChatMessage message) {
+        ChatMessage saved = service.addMessage(message);
+        template.convertAndSend("/topic/messages", saved);
+        return saved;
+    }
+
+    @GetMapping("/history")
+    @ResponseBody
+    public List<ChatMessage> history() {
+        return service.getHistory();
+    }
+
+    @PostMapping("/join")
+    @ResponseBody
+    public List<String> join(@RequestBody UserRequest user) {
+        service.addUser(user.getName());
+        List<String> users = List.copyOf(service.getUsers());
+        template.convertAndSend("/topic/users", users);
+        return users;
+    }
+
+    @PostMapping("/leave")
+    @ResponseBody
+    public List<String> leave(@RequestBody UserRequest user) {
+        service.removeUser(user.getName());
+        List<String> users = List.copyOf(service.getUsers());
+        template.convertAndSend("/topic/users", users);
+        return users;
+    }
+
+    @GetMapping("/users")
+    @ResponseBody
+    public List<String> users() {
+        return List.copyOf(service.getUsers());
+    }
+}

--- a/src/main/java/com/example/chat/ChatMessage.java
+++ b/src/main/java/com/example/chat/ChatMessage.java
@@ -1,0 +1,40 @@
+package com.example.chat;
+
+import java.time.Instant;
+
+public class ChatMessage {
+    private String from;
+    private String content;
+    private Instant timestamp;
+
+    public ChatMessage() {}
+
+    public ChatMessage(String from, String content) {
+        this.from = from;
+        this.content = content;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/chat/ChatService.java
+++ b/src/main/java/com/example/chat/ChatService.java
@@ -1,0 +1,40 @@
+package com.example.chat;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+@Service
+public class ChatService {
+    private final List<ChatMessage> history = new CopyOnWriteArrayList<>();
+    private final Set<String> users = new CopyOnWriteArraySet<>();
+
+    public ChatMessage addMessage(ChatMessage message) {
+        message.setTimestamp(Instant.now());
+        history.add(message);
+        if (history.size() > 100) {
+            history.remove(0);
+        }
+        return message;
+    }
+
+    public List<ChatMessage> getHistory() {
+        return List.copyOf(history);
+    }
+
+    public boolean addUser(String name) {
+        return users.add(name);
+    }
+
+    public boolean removeUser(String name) {
+        return users.remove(name);
+    }
+
+    public Set<String> getUsers() {
+        return Set.copyOf(users);
+    }
+}

--- a/src/main/java/com/example/chat/WebSocketConfig.java
+++ b/src/main/java/com/example/chat/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.example.chat;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat").withSockJS();
+    }
+}

--- a/src/main/java/com/example/chat/dto/UserRequest.java
+++ b/src/main/java/com/example/chat/dto/UserRequest.java
@@ -1,0 +1,13 @@
+package com.example.chat.dto;
+
+public class UserRequest {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Chat</title>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs@2/dist/stomp.min.js"></script>
+</head>
+<body>
+<h1>WebSocket Chat</h1>
+<div style="display:flex;gap:10px;">
+  <div style="flex:1;">
+    <h3>Messages</h3>
+    <div id="messages" style="height:200px; overflow-y:auto; border:1px solid #ccc;"></div>
+  </div>
+  <div style="width:150px;">
+    <h3>Users</h3>
+    <ul id="users" style="height:200px; overflow-y:auto; border:1px solid #ccc;"></ul>
+  </div>
+</div>
+<input id="from" placeholder="Name" />
+<input id="content" placeholder="Message" />
+<button onclick="send()">Send</button>
+<script>
+  var sock = new SockJS('/chat');
+  var stomp = Stomp.over(sock);
+  stomp.connect({}, function() {
+    join();
+    stomp.subscribe('/topic/messages', function(m) {
+      var msg = JSON.parse(m.body);
+      var div = document.getElementById('messages');
+      div.innerHTML += '<p><b>' + msg.from + ':</b> ' + msg.content + '</p>';
+      div.scrollTop = div.scrollHeight;
+    });
+    stomp.subscribe('/topic/users', function(m) {
+      var list = JSON.parse(m.body);
+      var ul = document.getElementById('users');
+      ul.innerHTML = '';
+      list.forEach(function(u) {
+        ul.innerHTML += '<li>' + u + '</li>';
+      });
+    });
+  });
+
+  function join() {
+    var name = document.getElementById('from').value;
+    fetch('/join', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({name:name})
+    });
+  }
+
+  function leave() {
+    var name = document.getElementById('from').value;
+    fetch('/leave', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({name:name})
+    });
+  }
+  function send() {
+    var msg = {
+      from: document.getElementById('from').value,
+      content: document.getElementById('content').value
+    };
+    stomp.send('/app/chat', {}, JSON.stringify(msg));
+    document.getElementById('content').value = '';
+  }
+  window.addEventListener('beforeunload', leave);
+</script>
+</body>
+</html>

--- a/src/test/java/com/example/chat/ChatServiceTest.java
+++ b/src/test/java/com/example/chat/ChatServiceTest.java
@@ -1,0 +1,25 @@
+package com.example.chat;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatServiceTest {
+    @Test
+    void historyLimitedTo100() {
+        ChatService service = new ChatService();
+        for (int i = 0; i < 120; i++) {
+            service.addMessage(new ChatMessage("u", "m" + i));
+        }
+        assertEquals(100, service.getHistory().size());
+        assertEquals("m20", service.getHistory().get(0).getContent());
+    }
+
+    @Test
+    void userJoinAndLeave() {
+        ChatService service = new ChatService();
+        assertTrue(service.addUser("alice"));
+        assertTrue(service.getUsers().contains("alice"));
+        assertTrue(service.removeUser("alice"));
+        assertFalse(service.getUsers().contains("alice"));
+    }
+}


### PR DESCRIPTION
## Summary
- add ChatService for storing chat messages up to 100 entries
- send messages over REST with `/send` and broadcast via WebSocket
- tag each `ChatMessage` with a timestamp
- bundle simple web client in `src/main/resources/static/index.html`
- document new features in README
- add basic unit test for `ChatService`
- add presence tracking endpoints and client updates

## Testing
- ❌ `mvn -q test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2180f648326a69a4c486ea94647